### PR TITLE
[FEAT] Adding optional timestamp field

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,2 +1,12 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -2,3 +2,6 @@ name = "PromClient"
 uuid = "880e31e2-b695-45be-a28d-96ac068cb1ee"
 authors = ["Hansang Ye <ye.hansang@gmail.com>"]
 version = "0.1.0"
+
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/PromClient.jl
+++ b/src/PromClient.jl
@@ -1,9 +1,12 @@
 module PromClient
 
+using Dates
+
 include("types.jl")
 include("metrics.jl")
 include("exposition.jl")
 include("collectors.jl")
+include("utilities.jl")
 
 # export PromMetric  # abstract class, do we need to export?
 export CounterMetric, GaugeMetric, HistogramMetric

--- a/src/collectors.jl
+++ b/src/collectors.jl
@@ -6,10 +6,8 @@ const DEFAULT_COLLECTOR = PromCollector("DEFAULT")
 
 """ Adds the given metric to a given collector. uses the DEFAULT_COLLECTOR if non given"""
 function add_metric_to_collector!(p::PromMetric, collector=DEFAULT_COLLECTOR)
-    for c in collector
-        if c.name == p.name
-            @error("Duplicate prom metrics with name $(c.name) have been added! Logging may be incorrect!")
-        end
+    if haskey(collector.metrics, p.name)
+        @error("Duplicate prom metrics with name $(p.name) have been added! Logging may be incorrect!")
     end
-    push!(collector, p)
+    collector.metrics[p.name] = p
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,0 +1,7 @@
+"""
+    datetime2epoch(dt::DateTime) -> Int64
+
+Take the given `DateTime` and return the number of seconds
+since the unix epoch `1970-01-01T00:00:00` as a [`Int64`](@ref).
+"""
+datetime2epoch(dt::DateTime) = Dates.value(dt) - Dates.UNIXEPOCH

--- a/test/collector_tests.jl
+++ b/test/collector_tests.jl
@@ -9,7 +9,7 @@ end
 end
 
 @testset "Collector Tests" begin
-    count("\n", generate_latest_prom_metrics()) == 21
-    count("testCounter{", generate_latest_prom_metrics()) == 4
-    length(PromClient.DEFAULT_COLLECTOR) == count("TYPE", generate_latest_prom_metrics())  # 4
+    @test count("\n", PromClient.generate_latest_collector_metrics()) == 16
+    @test count("test:Counter{", PromClient.generate_latest_collector_metrics()) == 4
+    @test length(PromClient.DEFAULT_COLLECTOR.metrics) == count("TYPE", PromClient.generate_latest_collector_metrics())  # 4
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
 using Test
 using PromClient
 
-# @testset "Collector Tests" begin include("collector_tests.jl") end
 @testset "Metric Tests" begin include("metric_tests.jl") end
-
+@testset "Collector Tests" begin include("collector_tests.jl") end
 
 
 # TODO


### PR DESCRIPTION
**Summary**

- Added optional timestamp field all structs.
- Added `_update_timestamp()` field to update the timestamp field if the `log_timestamp` field is set in the respective structs. 
- Updated the `collect()` and `generate_latest_collector_metrics()` methods to function with the new optional timestamp field.
- Added Dates package in order to create the `datetime2epoch()` method in the new `utilities.jl` file to retrieve timestamp for the optional timestamp field.
- Fixed `add_metric_to_collector!()` to function with the new `DEFAULT_COLLECTOR`.
- Fixed `generate_latest_collector_metrics()` method to function with the new `DEFAULT_COLLECTOR`.
- Fixed the syntax within `_get_label_key_val()`, `set()` and `observe()` to match the `_lk` field within the respective structs.
- Updated unit-tests to function with the new flow.